### PR TITLE
Add tensorflow version for Apple Silicon

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 docopt
 grpcio
-tensorflow==2.12
+tensorflow==2.12; sys_platform != 'darwin' or platform_machine != 'arm64'
+tensorflow-macos==2.12; sys_platform == 'darwin' and platform_machine == 'arm64'
 scikit-learn==1.2.2
 matplotlib==3.7.1
 seaborn==0.12.2


### PR DESCRIPTION
I did not try apptainer and instead tried to install venv with requirements.txt. But it failed at `tensorflow==2.12` because pip cannot find the package for Apple Silicon (M1 chips):
```
ERROR: Could not find a version that satisfies the requirement tensorflow==2.12 (from versions: 2.13.0rc0, 2.13.0rc1, 2.13.0rc2, 2.13.0, 2.14.0rc0)
ERROR: No matching distribution found for tensorflow==2.12
```
On these machines one needs to run `pip3 install tensorflow-macos==2.12` instead, and we can cover all cases by adding conditionals that check the architecture – as in this commit. 
We could also simply drop the version for `tensorflow`, which solves my problem as well (or keep calm and use apptainer 🤷‍♂️)